### PR TITLE
Publisher now runs in its own thread with own streaming connection (shared underlying nats connection)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 *.DS_Store
 *checkstyle_report*.txt
+application.properties

--- a/src/main/java/org/mskcc/cmo/messaging/Gateway.java
+++ b/src/main/java/org/mskcc/cmo/messaging/Gateway.java
@@ -2,10 +2,8 @@ package org.mskcc.cmo.messaging;
 
 public interface Gateway {
 
-    void publish(String topic, Object message) throws Exception;
-
-    void subscribe(String topic, Class messageClass, MessageConsumer messageConsumer) throws Exception;
-
-    void shutdown() throws Exception;
-
+    void initialize() throws Exception;
+	void publish(String topic, Object message) throws Exception;
+	void subscribe(String topic, Class messageClass, MessageConsumer messageConsumer) throws Exception;
+	void shutdown() throws Exception;
 }


### PR DESCRIPTION
This PR introduces a publishing worker thread (single thread) and blocking queue to implement a producer-consumer pattern between publisher requests and fulfillment.  Code does not take advantage of NATS streaming ackHandler as managing lost acks is more trouble than its worth.

Currently, this code does not handle exceptions thrown during publishing.   This should be revisited and perhaps an attempt to requeue a message that failed publication should be introduced.