### PR TITLE
PublisherQueue while loop logic update

### DIFF
--- a/src/main/java/org/mskcc/cmo/messaging/impl/NATSGatewayImpl.java
+++ b/src/main/java/org/mskcc/cmo/messaging/impl/NATSGatewayImpl.java
@@ -97,7 +97,7 @@ public class NATSGatewayImpl implements Gateway {
                             LOG.debug("Message contents: " + msg);
                         }
                     }
-                    if (interrupted && publishingQueue.isEmpty()) {
+                    if ((interrupted || shutdownInitiated) && publishingQueue.isEmpty()) {
                         break;
                     }
                 } catch (InterruptedException e) {
@@ -143,6 +143,9 @@ public class NATSGatewayImpl implements Gateway {
 
     @Override
     public boolean isConnected() {
+        if (stanConnection == null) {
+            return Boolean.FALSE;
+        }
         return (stanConnection != null && stanConnection.getNatsConnection() != null
                 && (stanConnection.getNatsConnection().getStatus().CONNECTED.equals(Status.CONNECTED)));
     }


### PR DESCRIPTION
Break from the while loop that's polling for new messages to publish
if interrupt is true OR shutdown has been initiated && queue is empty.

Interrupt was not getting set to true during exec.shutdownNow().

Signed-off-by: Angelica Ochoa <ochoaa@mskcc.org>