### PR TITLE
Set up exactly once delivery for jetstream

### DIFF
--- a/src/main/java/org/mskcc/cmo/messaging/Gateway.java
+++ b/src/main/java/org/mskcc/cmo/messaging/Gateway.java
@@ -9,6 +9,8 @@ public interface Gateway {
     boolean isConnected();
 
     void publish(String subject, Object message) throws Exception;
+    
+    void publish(String msgId, String subject, Object message) throws Exception;
 
     void subscribe(String subject, Class messageClass,
             MessageConsumer messageConsumer) throws Exception;

--- a/src/main/java/org/mskcc/cmo/messaging/MessageConsumer.java
+++ b/src/main/java/org/mskcc/cmo/messaging/MessageConsumer.java
@@ -1,7 +1,9 @@
 package org.mskcc.cmo.messaging;
 
+import io.nats.client.Message;
+
 public interface MessageConsumer {
 
-    void onMessage(Object message);
+    void onMessage(Message msg, Object message);
 
 }


### PR DESCRIPTION
Changed constructor for MessageConsumer.onMessage() handling.

- When handling the message the Message (NATS client java class) will contain
 the message id
- New publish method also accepts a custom message id that it will add to the message
 headers for the server to track duplicate messages given a time window

Co-authored-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
Co-authored-by: Divya Madala <71040191+divyamadala30@users.noreply.github.com>
Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>