### PR TITLE
Resolve error w/message subject filtering

### DIFF
--- a/src/main/java/org/mskcc/cmo/messaging/impl/JSGatewayImpl.java
+++ b/src/main/java/org/mskcc/cmo/messaging/impl/JSGatewayImpl.java
@@ -68,7 +68,7 @@ public class JSGatewayImpl implements Gateway {
     @Value("${nats.consumer_password}")
     public String consumerPassword;
 
-    @Value("${nats.filter_subject:METADB.*}")
+    @Value("${nats.filter_subject}")
     public String filterSubject;
 
     @Value("${nats.request_wait_time_in_seconds:10}")
@@ -161,8 +161,8 @@ public class JSGatewayImpl implements Gateway {
             PushSubscribeOptions options = PushSubscribeOptions.builder()
                     .configuration(consumerConfig)
                     .build();
-            JetStreamSubscription sub = jsConnection.subscribe(subject, dispatcher,
-                msg -> onMessage(subject, msg, messageClass, messageConsumer), false, options);
+            JetStreamSubscription sub = jsConnection.subscribe(filterSubject, dispatcher,
+                msg -> onMessage(msg, messageClass, messageConsumer), false, options);
             subscribers.put(subject, sub);
         }
     }
@@ -184,11 +184,11 @@ public class JSGatewayImpl implements Gateway {
      * @param messageClass
      * @param messageConsumer
      */
-    public void onMessage(String subject, Message msg, Class messageClass, MessageConsumer messageConsumer) {
+    public void onMessage(Message msg, Class messageClass, MessageConsumer messageConsumer) {
         Boolean subjectMatches = Boolean.FALSE;
         if (msg.hasHeaders()) {
             List<String> hdrContents = msg.getHeaders().get("Nats-Msg-Subject");
-            if (hdrContents.size() == 1 && hdrContents.get(0).endsWith(subject)) {
+            if (hdrContents.size() == 1 && hdrContents.get(0).endsWith(msg.getSubject())) {
                 subjectMatches = Boolean.TRUE;
             }
         }


### PR DESCRIPTION
Filter subject is used to register subscribers but the handler uses the specific subject topic
to determine whether a message should be handled by the particular subscriber or not.

Filter subject must match exactly the filter subject that the consumer is set up with.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>